### PR TITLE
fix: Unequip Permission Logic

### DIFF
--- a/src/main/java/me/Tonus_/hatCosmetics/command/MainCommand.java
+++ b/src/main/java/me/Tonus_/hatCosmetics/command/MainCommand.java
@@ -59,15 +59,19 @@ public class MainCommand extends BaseCommand {
     }
 
     @Subcommand("unequip|u")
-    public void onUnequip(@NotNull Player player) {
-        equipManager.unequip(player, null);
-    }
-
-    @Subcommand("unequip|u")
     @CommandCompletion("@players")
-    @CommandPermission(PermissionNode.ADMIN_UNEQUIP_OTHER)
-    public void onUnequipAdmin(@NotNull Player sender, Player target) {
-        equipManager.unequip(target, sender);
+    public void onUnequip(@NotNull Player player, @Optional Player target) {
+        if (target != null) {
+            if (!player.hasPermission(PermissionNode.ADMIN_UNEQUIP_OTHER)) {
+                messageRetriever.sendMessage(player, MessageReference.COSMETIC_NO_PERMISSION_LONG);
+                return;
+            }
+
+            equipManager.unequip(target, player);
+            return;
+        }
+
+        equipManager.unequip(player, null);
     }
 
     @Subcommand("reload|r")


### PR DESCRIPTION
## Description
[//]: # (Provide a brief description of the changes in this pull request)

The unequip admin command prevents a normal user from using the unequip command.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update

## How Has This Been Tested?
[//]: # (Describe the tests you ran to verify your changes)

Tested on a local server.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
[//]: # (Add any additional information or context about the pull request here)

